### PR TITLE
Use more unique function and class names

### DIFF
--- a/includes/class-wcxrp-helpers.php
+++ b/includes/class-wcxrp-helpers.php
@@ -1,7 +1,7 @@
 <?php
 
 
-class Helpers
+class WCXRP_Helpers
 {
     /**
      * Ugly helper to print pretty statuses.

--- a/includes/class-wcxrp-ledger.php
+++ b/includes/class-wcxrp-ledger.php
@@ -1,7 +1,7 @@
 <?php
 
 
-class Ledger
+class WCXRP_Ledger
 {
     private $node = false;
     private $headers = [];

--- a/includes/class-wcxrp-rates.php
+++ b/includes/class-wcxrp-rates.php
@@ -1,6 +1,6 @@
 <?php
 
-class Rates {
+class WCXRP_Rates {
     private $ecb_cache = 'woo_ecb_rates.xml';
 
     /**

--- a/includes/class-wcxrp-webhooks.php
+++ b/includes/class-wcxrp-webhooks.php
@@ -1,6 +1,6 @@
 <?php
 
-class Webhook {
+class WCXRP_Webhook {
 
     protected $pub;
     protected $secret;


### PR DESCRIPTION
To avoid colliding with other plugins, prefix all classes with
WCXRP_ and all functions with wc_gateway_xrp_.